### PR TITLE
Implement character exclusion in password generator

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -406,26 +406,45 @@ impl EncryptionContext {
     /// Generate random password
     pub fn generate_password(&self, settings: &crate::models::PasswordGeneratorSettings) -> String {
         let mut rng = rand::thread_rng();
-        let mut groups: Vec<&[u8]> = Vec::new();
+        let mut groups: Vec<Vec<u8>> = Vec::new();
 
         if settings.use_lowercase {
-            groups.push(b"abcdefghijklmnopqrstuvwxyz");
+            groups.push(b"abcdefghijklmnopqrstuvwxyz".to_vec());
         }
         if settings.use_uppercase {
-            groups.push(b"ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+            groups.push(b"ABCDEFGHIJKLMNOPQRSTUVWXYZ".to_vec());
         }
         if settings.use_numbers {
-            groups.push(b"0123456789");
+            groups.push(b"0123456789".to_vec());
         }
         if settings.use_symbols {
-            groups.push(b"!@#$%^&*()_+-=[]{}|;:,.<>?");
+            groups.push(b"!@#$%^&*()_+-=[]{}|;:,.<>?".to_vec());
         }
 
         if groups.is_empty() {
-            groups.push(b"abcdefghijklmnopqrstuvwxyz");
+            groups.push(b"abcdefghijklmnopqrstuvwxyz".to_vec());
         }
 
-        let chars: Vec<u8> = groups.concat();
+        // Remove similar or ambiguous characters if requested
+        if settings.exclude_similar || settings.exclude_ambiguous {
+            let similar = b"il1Lo0O";
+            let ambiguous = b"{}[]()/\\'\"`~,;:.<>";
+            for group in &mut groups {
+                if settings.exclude_similar {
+                    group.retain(|c| !similar.contains(c));
+                }
+                if settings.exclude_ambiguous {
+                    group.retain(|c| !ambiguous.contains(c));
+                }
+            }
+            // Remove any groups that became empty after filtering
+            groups.retain(|g| !g.is_empty());
+            if groups.is_empty() {
+                groups.push(b"abcdefghijklmnopqrstuvwxyz".to_vec());
+            }
+        }
+
+        let chars: Vec<u8> = groups.iter().flatten().cloned().collect();
         let mut password: Vec<char> = Vec::with_capacity(settings.length as usize);
 
         for group in &groups {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -114,6 +114,30 @@ mod tests {
     }
 
     #[test]
+    fn test_password_generation_excludes_sets() {
+        let settings = test_security_settings();
+
+        let context =
+            EncryptionContext::new("test_password", SecurityLevel::Standard, settings).unwrap();
+
+        let settings = PasswordGeneratorSettings {
+            length: 32,
+            use_uppercase: true,
+            use_lowercase: true,
+            use_numbers: true,
+            use_symbols: true,
+            exclude_similar: true,
+            exclude_ambiguous: true,
+        };
+
+        let password = context.generate_password(&settings);
+        let similar = "il1Lo0O";
+        let ambiguous = "{}[]()/\\'\"`~,;:.<>";
+        assert!(!password.chars().any(|c| similar.contains(c)));
+        assert!(!password.chars().any(|c| ambiguous.contains(c)));
+    }
+
+    #[test]
     fn test_database_creation() {
         let manager =
             DatabaseManager::new("Test Database".to_string(), SecurityLevel::High).unwrap();


### PR DESCRIPTION
## Summary
- honor `exclude_similar` and `exclude_ambiguous` flags in password generator
- add tests ensuring excluded characters never appear in generated passwords

## Testing
- `cargo test`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_e_68a44a36f18c832f84def5528ba50c17