### PR TITLE
Refactor progress callback to avoid unnecessary locking

### DIFF
--- a/src/cli/progress.rs
+++ b/src/cli/progress.rs
@@ -67,14 +67,13 @@ pub fn demo_progress_indicator() -> Result<()> {
     );
 
     let progress_bar = Arc::new(Mutex::new(CliProgressBar::new()));
-    let progress_bar_clone = progress_bar.clone();
+    let progress_bar_clone = Arc::clone(&progress_bar);
 
-    let progress_callback: ProgressCallback =
-        Arc::new(Mutex::new(move |message: &str, progress: f32| {
-            if let Ok(mut bar) = progress_bar_clone.lock() {
-                bar.update(message, progress);
-            }
-        }));
+    let progress_callback: ProgressCallback = Arc::new(move |message: &str, progress: f32| {
+        if let Ok(mut bar) = progress_bar_clone.lock() {
+            bar.update(message, progress);
+        }
+    });
 
     println!("\n📊 Creating encryption context with high security...");
     let settings = SecuritySettings {

--- a/src/database.rs
+++ b/src/database.rs
@@ -134,9 +134,7 @@ impl DatabaseManager {
             .map_err(|e| anyhow!("Failed to deserialize database: {}", e))?;
 
         if let Some(callback) = &progress_callback {
-            if let Ok(callback) = callback.lock() {
-                callback("Database loaded successfully", 1.0);
-            }
+            callback("Database loaded successfully", 1.0);
         }
 
         Ok(Self {
@@ -174,9 +172,7 @@ impl DatabaseManager {
 
         // Serialize database
         if let Some(callback) = &progress_callback {
-            if let Ok(callback) = callback.lock() {
-                callback("Serializing database", 0.3);
-            }
+            callback("Serializing database", 0.3);
         }
         let json_data = serde_json::to_vec(&self.database)
             .map_err(|e| anyhow!("Failed to serialize database: {}", e))?;
@@ -186,9 +182,7 @@ impl DatabaseManager {
 
         // Encrypt data
         if let Some(callback) = &progress_callback {
-            if let Ok(callback) = callback.lock() {
-                callback("Encrypting database", 0.6);
-            }
+            callback("Encrypting database", 0.6);
         }
         let encrypted_data = encryption_context.encrypt(&json_data)?;
 
@@ -214,17 +208,13 @@ impl DatabaseManager {
 
         // Write to file
         if let Some(callback) = &progress_callback {
-            if let Ok(callback) = callback.lock() {
-                callback("Writing to file", 0.9);
-            }
+            callback("Writing to file", 0.9);
         }
         fs::write(file_path, file_bytes)
             .map_err(|e| anyhow!("Failed to write database file: {}", e))?;
 
         if let Some(callback) = &progress_callback {
-            if let Ok(callback) = callback.lock() {
-                callback("Database saved successfully", 1.0);
-            }
+            callback("Database saved successfully", 1.0);
         }
 
         self.encryption_context = Some(encryption_context);


### PR DESCRIPTION
## Summary
- remove `Mutex` from `ProgressCallback` and update all call sites
- simplify CLI progress demo to use the new callback
- streamline database save/load progress reporting

## Testing
- `cargo test`
- `cargo clippy -- -D warnings`

------
https://chatgpt.com/codex/tasks/task_e_68a45f94ebd8832fb559b5603482737d