### PR TITLE
Use constant-time HMAC verification for database integrity

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -336,9 +336,9 @@ impl DatabaseManager {
             // Verify HMAC against the last loaded/saved HMAC
             let json_data = serde_json::to_vec(&self.database)
                 .map_err(|e| anyhow!("Failed to serialize database: {}", e))?;
-            let current_hmac = ctx.compute_hmac(&json_data)?;
             if let Some(file_hmac) = &self.file_hmac {
-                Ok(&current_hmac == file_hmac)
+                // Use constant-time verification via HMAC API
+                ctx.verify_hmac(&json_data, file_hmac)
             } else {
                 Ok(true)
             }


### PR DESCRIPTION
## Summary
- Avoid timing leaks by verifying stored HMAC with constant-time `verify_hmac`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a4918e2c08832fad5a0a682a9a154b