### PR TITLE
refactor: replace key hashmap with structured fields

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -25,7 +25,8 @@ mod tests {
 
         assert_eq!(context.security_level, SecurityLevel::High);
         assert_eq!(context.salt.len(), 32);
-        assert!(!context.derived_keys.is_empty());
+        assert_eq!(context.aes_key.len(), 32);
+        assert_eq!(context.integrity_key.len(), 32);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- inline derived AES/HMAC keys into `EncryptionContext`
- zeroize keys individually
- update tests for new key fields

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a49c415558832f869a02d08221119f