### PR TITLE
Use constant-time hash comparison for item integrity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
+ "subtle",
  "tempfile",
  "thiserror",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "1.0"
 # File system and I/O
 base64 = "0.21.5"
 sha3 = "0.10"
+subtle = "2.5"
 
 # Time handling
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
## Summary
- add `subtle` dependency for constant-time equality
- verify stored item hashes using constant-time comparison
- refactor SHA-256 helpers for reuse

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a49fc66318832f94cb3b93a59e9581