### PR TITLE
refactor: decouple password generation from encryption context

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -503,13 +503,7 @@ impl CliHandler {
             exclude_ambiguous: false,
         };
 
-        let encryption_context = crate::crypto::EncryptionContext::new(
-            "temp",
-            SecurityLevel::Standard,
-            crate::models::SecuritySettings::default(),
-        )?;
-
-        let password = encryption_context.generate_password(&settings);
+        let password = crate::crypto::generate_password(&settings);
         term.write_line(&format!("Generated password: {password}"))?;
 
         Ok(())

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -398,66 +398,71 @@ impl EncryptionContext {
 
         Ok(())
     }
+}
 
-    /// Generate random password
-    pub fn generate_password(&self, settings: &crate::models::PasswordGeneratorSettings) -> String {
-        let mut rng = rand::thread_rng();
-        let mut groups: Vec<Vec<u8>> = Vec::new();
+/// Generate a random password using the provided settings.
+///
+/// This standalone function avoids the heavy initialization cost of an
+/// `EncryptionContext` while still providing secure password generation. It
+/// uses a cryptographically secure random number generator from the `rand`
+/// crate and supports character set filtering for improved usability.
+pub fn generate_password(settings: &crate::models::PasswordGeneratorSettings) -> String {
+    let mut rng = rand::thread_rng();
+    let mut groups: Vec<Vec<u8>> = Vec::new();
 
-        if settings.use_lowercase {
-            groups.push(b"abcdefghijklmnopqrstuvwxyz".to_vec());
-        }
-        if settings.use_uppercase {
-            groups.push(b"ABCDEFGHIJKLMNOPQRSTUVWXYZ".to_vec());
-        }
-        if settings.use_numbers {
-            groups.push(b"0123456789".to_vec());
-        }
-        if settings.use_symbols {
-            groups.push(b"!@#$%^&*()_+-=[]{}|;:,.<>?".to_vec());
-        }
+    if settings.use_lowercase {
+        groups.push(b"abcdefghijklmnopqrstuvwxyz".to_vec());
+    }
+    if settings.use_uppercase {
+        groups.push(b"ABCDEFGHIJKLMNOPQRSTUVWXYZ".to_vec());
+    }
+    if settings.use_numbers {
+        groups.push(b"0123456789".to_vec());
+    }
+    if settings.use_symbols {
+        groups.push(b"!@#$%^&*()_+-=[]{}|;:,.<>?".to_vec());
+    }
 
+    if groups.is_empty() {
+        groups.push(b"abcdefghijklmnopqrstuvwxyz".to_vec());
+    }
+
+    // Remove similar or ambiguous characters if requested
+    if settings.exclude_similar || settings.exclude_ambiguous {
+        let similar = b"il1Lo0O";
+        let ambiguous = b"{}[]()/\\'\"`~,;:.<>";
+        for group in &mut groups {
+            if settings.exclude_similar {
+                group.retain(|c| !similar.contains(c));
+            }
+            if settings.exclude_ambiguous {
+                group.retain(|c| !ambiguous.contains(c));
+            }
+        }
+        // Remove any groups that became empty after filtering
+        groups.retain(|g| !g.is_empty());
         if groups.is_empty() {
             groups.push(b"abcdefghijklmnopqrstuvwxyz".to_vec());
         }
+    }
 
-        // Remove similar or ambiguous characters if requested
-        if settings.exclude_similar || settings.exclude_ambiguous {
-            let similar = b"il1Lo0O";
-            let ambiguous = b"{}[]()/\\'\"`~,;:.<>";
-            for group in &mut groups {
-                if settings.exclude_similar {
-                    group.retain(|c| !similar.contains(c));
-                }
-                if settings.exclude_ambiguous {
-                    group.retain(|c| !ambiguous.contains(c));
-                }
-            }
-            // Remove any groups that became empty after filtering
-            groups.retain(|g| !g.is_empty());
-            if groups.is_empty() {
-                groups.push(b"abcdefghijklmnopqrstuvwxyz".to_vec());
-            }
-        }
+    let chars: Vec<u8> = groups.iter().flatten().cloned().collect();
+    let mut password: Vec<char> = Vec::with_capacity(settings.length as usize);
 
-        let chars: Vec<u8> = groups.iter().flatten().cloned().collect();
-        let mut password: Vec<char> = Vec::with_capacity(settings.length as usize);
-
-        for group in &groups {
-            if password.len() < settings.length as usize {
-                if let Some(&ch) = group.choose(&mut rng) {
-                    password.push(ch as char);
-                }
-            }
-        }
-
-        while password.len() < settings.length as usize {
-            if let Some(&ch) = chars.choose(&mut rng) {
+    for group in &groups {
+        if password.len() < settings.length as usize {
+            if let Some(&ch) = group.choose(&mut rng) {
                 password.push(ch as char);
             }
         }
-
-        password.shuffle(&mut rng);
-        password.into_iter().collect()
     }
+
+    while password.len() < settings.length as usize {
+        if let Some(&ch) = chars.choose(&mut rng) {
+            password.push(ch as char);
+        }
+    }
+
+    password.shuffle(&mut rng);
+    password.into_iter().collect()
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::crypto::EncryptionContext;
+    use crate::crypto::{generate_password, EncryptionContext};
     use crate::database::DatabaseManager;
     use crate::models::*;
     use chrono::Utc;
@@ -91,11 +91,6 @@ mod tests {
 
     #[test]
     fn test_password_generation() {
-        let settings = test_security_settings();
-
-        let context =
-            EncryptionContext::new("test_password", SecurityLevel::Standard, settings).unwrap();
-
         let settings = PasswordGeneratorSettings {
             length: 16,
             use_uppercase: true,
@@ -106,7 +101,7 @@ mod tests {
             exclude_ambiguous: false,
         };
 
-        let password = context.generate_password(&settings);
+        let password = generate_password(&settings);
         assert_eq!(password.len(), 16);
         assert!(password.chars().any(|c| c.is_uppercase()));
         assert!(password.chars().any(|c| c.is_lowercase()));
@@ -116,11 +111,6 @@ mod tests {
 
     #[test]
     fn test_password_generation_excludes_sets() {
-        let settings = test_security_settings();
-
-        let context =
-            EncryptionContext::new("test_password", SecurityLevel::Standard, settings).unwrap();
-
         let settings = PasswordGeneratorSettings {
             length: 32,
             use_uppercase: true,
@@ -131,7 +121,7 @@ mod tests {
             exclude_ambiguous: true,
         };
 
-        let password = context.generate_password(&settings);
+        let password = generate_password(&settings);
         let similar = "il1Lo0O";
         let ambiguous = "{}[]()/\\'\"`~,;:.<>";
         assert!(!password.chars().any(|c| similar.contains(c)));


### PR DESCRIPTION
## Summary
- avoid expensive encryption context initialization when generating passwords
- provide standalone `generate_password` utility
- update CLI and tests to use the new function

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a52523b4832f907308017febeaa1