### PR TITLE
refactor: tune security defaults

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -40,7 +40,10 @@ impl DatabaseManager {
         security_level: SecurityLevel,
         _progress_callback: Option<ProgressCallback>,
     ) -> Result<Self> {
-        let _settings = SecuritySettings::default();
+        let settings = DatabaseSettings {
+            security_settings: SecuritySettings::recommended(security_level.clone()),
+            ..DatabaseSettings::default()
+        };
         let database = PasswordDatabase {
             version: "1.0.0".to_string(),
             created_at: Utc::now(),
@@ -50,7 +53,7 @@ impl DatabaseManager {
             metadata: crate::models::DatabaseMetadata {
                 name,
                 description: None,
-                settings: DatabaseSettings::default(),
+                settings,
                 custom_fields: std::collections::HashMap::new(),
             },
             integrity_hash: String::new(),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -17,8 +17,7 @@ mod tests {
 
     #[test]
     fn test_encryption_context_creation() {
-        let mut settings = SecuritySettings::default();
-        settings.key_derivation_iterations = 10; // Very reduced for CI testing
+        let settings = test_security_settings();
 
         let context =
             EncryptionContext::new("test_password", SecurityLevel::High, settings).unwrap();
@@ -31,8 +30,7 @@ mod tests {
 
     #[test]
     fn test_encryption_decryption() {
-        let mut settings = SecuritySettings::default();
-        settings.key_derivation_iterations = 10; // Very reduced for CI testing
+        let settings = test_security_settings();
 
         let context =
             EncryptionContext::new("test_password", SecurityLevel::Standard, settings).unwrap();


### PR DESCRIPTION
## Summary
- adjust default security settings to hardware-aware values
- initialize new databases with level-specific KDF parameters
- use lightweight security settings in tests

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a4c63e7324832f9379b58f15ae0eea