### PR TITLE
Add clipboard auto-clear with configurable timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,10 @@ password_manager show --file passwords.db --id <item-uuid>
 
 #### Generate Password
 ```bash
-password_manager generate --length 32 --uppercase --lowercase --numbers --symbols
+password_manager generate --length 32 --uppercase --lowercase --numbers --symbols --timeout 45
 ```
+The generated password is copied to your clipboard and restored to its previous
+contents after the specified timeout (30 seconds by default).
 
 #### Verify Database Integrity
 ```bash

--- a/src/cli/clipboard.rs
+++ b/src/cli/clipboard.rs
@@ -1,11 +1,38 @@
 use anyhow::{anyhow, Result};
+use std::{thread, time::Duration};
+use zeroize::Zeroizing;
 
-/// Copy the provided text to the system clipboard.
-pub fn copy_to_clipboard(text: &str) -> Result<()> {
+/// Copy the provided text to the system clipboard and optionally clear it
+/// after the given timeout. The previous clipboard contents are restored when
+/// possible. This function never prints the copied value.
+pub fn copy_to_clipboard(text: &str, timeout: Option<Duration>) -> Result<()> {
     let mut clipboard =
         arboard::Clipboard::new().map_err(|e| anyhow!("Failed to access clipboard: {e}"))?;
+
+    // Preserve current clipboard contents so we can restore them later. Failure
+    // to read the clipboard is not considered fatal; we simply won't restore it
+    // afterwards.
+    let previous = clipboard.get_text().ok().map(Zeroizing::new);
+
     clipboard
         .set_text(text.to_owned())
         .map_err(|e| anyhow!("Failed to copy to clipboard: {e}"))?;
+
+    if let Some(duration) = timeout {
+        // Spawn a background thread that waits for the timeout and then clears
+        // or restores the clipboard. Any errors during this best-effort cleanup
+        // are intentionally ignored to avoid exposing secrets.
+        thread::spawn(move || {
+            thread::sleep(duration);
+            if let Ok(mut cb) = arboard::Clipboard::new() {
+                if let Some(prev) = previous {
+                    let _ = cb.set_text(prev.to_string());
+                } else {
+                    let _ = cb.clear();
+                }
+            }
+        });
+    }
+
     Ok(())
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -9,7 +9,7 @@ use chrono::Utc;
 use clap::{Args, Parser, Subcommand};
 use console::{style, Term};
 use dialoguer::{Confirm, Input, Password};
-use std::path::Path;
+use std::{path::Path, time::Duration};
 use uuid::Uuid;
 use zeroize::Zeroizing;
 
@@ -178,6 +178,10 @@ pub struct GenerateArgs {
     /// Display the generated password in the terminal
     #[arg(long)]
     show: bool,
+
+    /// Seconds before the clipboard is cleared
+    #[arg(long, default_value = "30")]
+    timeout: u64,
 }
 
 #[derive(Args)]
@@ -508,7 +512,7 @@ impl CliHandler {
         };
 
         let password = Zeroizing::new(crate::crypto::generate_password(&settings));
-        copy_to_clipboard(&password)?;
+        copy_to_clipboard(&password, Some(Duration::from_secs(args.timeout)))?;
         if args.show {
             term.write_line(&format!("Generated password: {}", *password))?;
         } else {


### PR DESCRIPTION
## Summary
- Securely copy text to clipboard and restore previous contents after a timeout
- Allow `generate` command to configure clipboard timeout
- Document new timeout flag for password generation

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a6b9599c20832faf4cd0a421c9869d