### PR TITLE
Add Debian package release workflow

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -12,6 +12,7 @@ This repository includes a comprehensive CI/CD pipeline that automatically build
 4. **Build** - Multi-platform builds
 5. **Release** - GitHub releases
 6. **Publish** - Crates.io publishing
+7. **Debian Package** - Build .deb release for Ubuntu/Debian
 
 ### Supported Platforms
 
@@ -57,6 +58,7 @@ The pipeline creates the following artifacts:
 - `password_manager-windows-x86_64.zip`
 - `password_manager-macos-x86_64.tar.gz`
 - `password_manager-macos-aarch64.tar.gz`
+- `password_manager_amd64.deb`
 
 ## 🧪 Testing
 

--- a/.github/workflows/deb-release.yml
+++ b/.github/workflows/deb-release.yml
@@ -1,0 +1,58 @@
+name: Debian Package Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-deb:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-deb
+        run: cargo install cargo-deb
+
+      - name: Build Debian package
+        run: cargo deb --locked
+
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: debian-package
+          path: target/debian/*.deb
+
+  release:
+    runs-on: ubuntu-24.04
+    needs: build-deb
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: debian-package
+          path: dist
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*.deb"
+          allowUpdates: true
+          draft: false
+          prerelease: false
+          generateReleaseNotes: true
+          tag: ${{ github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- build and release a Debian `.deb` package for Ubuntu/Debian using GitHub Actions
- document new Debian package job and release artifact in CI/CD docs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a8b8a9e3b0832fa9b804f1364a6bdc