### PR TITLE
ci: remove invalid lockfile flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Build Debian package
       if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
-      run: cargo deb --offline -- --no-verify-lockfile
+      run: cargo deb --offline --locked
       
     - name: Install cargo-rpm
       if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}


### PR DESCRIPTION
## Summary
- fix debian package build by removing unsupported `--no-verify-lockfile` flag

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a97e4b83a8832fbfeb53ebd0d22662