### PR TITLE
ci: remove offline flags from package builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Build Debian package
       if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
-      run: cargo deb --offline --locked
+      run: cargo deb --locked
       
     - name: Install cargo-rpm
       if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
@@ -74,7 +74,7 @@ jobs:
 
     - name: Build RPM package
       if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
-      run: cargo rpm build --offline
+      run: cargo rpm build
       env:
         CARGO_TARGET_DIR: target/rpm
 


### PR DESCRIPTION
## Summary
- fix Debian package step by removing unsupported offline flag
- drop offline build mode for RPM packaging

## Testing
- `cargo fmt --all -- --check`
- `cargo test --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68a99ab86bc0832f86d40925ddb772a7