### PR TITLE
ci: simplify deb packaging command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Build Debian package
       if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
-      run: cargo deb --offline --locked
+      run: cargo deb
       
     - name: Install cargo-rpm
       if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
@@ -74,7 +74,7 @@ jobs:
 
     - name: Build RPM package
       if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
-      run: cargo rpm build --offline
+      run: cargo rpm build
       env:
         CARGO_TARGET_DIR: target/rpm
 

--- a/.github/workflows/deb-release.yml
+++ b/.github/workflows/deb-release.yml
@@ -25,7 +25,7 @@ jobs:
         run: cargo install cargo-deb
 
       - name: Build Debian package
-        run: cargo deb --locked
+        run: cargo deb
 
       - name: Upload .deb artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- run `cargo deb` without extra flags in build pipeline
- do the same for the dedicated Debian release workflow

## Testing
- `cargo fmt --all -- --check`
- `cargo test --all-features`


------
https://chatgpt.com/codex/tasks/task_e_68a99ab86bc0832f86d40925ddb772a7